### PR TITLE
Fixing assertion error

### DIFF
--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -121,8 +121,9 @@ def post_webhook(repo_token):
     log.debug(f'requests.post("{url}", json={json})')
     response = requests.post(url, json=json)
     response.raise_for_status()
-    log.debug(f"response.json(): {response.json()}")
-    assert response.json() == {"done": True}, response.json()
+    result = response.json()
+    log.debug(f"response.json(): {result}")
+    assert result.get("done", False), response.json()
 
 
 def str_to_bool(value):

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -123,7 +123,7 @@ def post_webhook(repo_token):
     response.raise_for_status()
     result = response.json()
     log.debug(f"response.json(): {result}")
-    assert result.get("done", False), response.json()
+    assert result.get("done", False), result
 
 
 def str_to_bool(value):


### PR DESCRIPTION
This pull request fixes the check applied to the webhook function. Perhaps the coveralls API has changed what it returns? But it no longer just returns `{done: true}` so the `assert` was failing even when it shouldn't.