### PR TITLE
fix for parallel mode, flag_name & base_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ jobs:
       uses: AndreMiras/coveralls-python-action@develop
       with:
         parallel: true
+        flag-name: Unit Test
 
   coveralls_finish:
     needs: test
@@ -56,6 +57,12 @@ jobs:
     # Set to `true` for the last action when using `parallel: true`.
     # Default: false
     parallel-finished: ''
+    # A name to identify the current job. This is useful in combination with `parallel: true`.
+    # Default: false
+    flag-name: ''
+    # A sub-directory in which coverage was executed.
+    # Default: false
+    base-path: ''
     # Set to true to increase logger verbosity.
     # Default: false
     debug: ''

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
   parallel-finished:
     description: 'Set to true for the last action when using `parallel: true`.'
     default: false
+  base-path:
+    description: 'The name of a sub-directory in which the coverage files are to be found.'
+    default: false
+  flag-name:
+    description: 'A description of the current job used in connection with parallel.'
+    default: false
   debug:
     description: 'Set to `true` to increase logger verbosity.'
     default: false
@@ -23,6 +29,10 @@ runs:
   args:
     - --github-token
     - ${{ inputs.github-token }}
+    - --base-path
+    - ${{ inputs.base-path }}
+    - --flag-name
+    - ${{ inputs.flag-name }}
     - --parallel
     - ${{ inputs.parallel }}
     - --parallel-finished

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -49,6 +49,7 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     # (depending on where it's ran from?)
     service_names = ("github", "github-actions")
     result = None
+    cwd = os.getcwd()
     log.debug(f"Current Working Directory: {cwd}")
     #if base_path:
     os.chdir(base_path)

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -49,8 +49,9 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     # (depending on where it's ran from?)
     service_names = ("github", "github-actions")
     result = None
-    if base_path:
-        os.chdir(base_path)
+    log.debug(f"Current Working Directory: {cwd}")
+    #if base_path:
+    os.chdir(base_path)
     cwd = os.getcwd()
     log.debug(f"Current Working Directory: {cwd}")
     for service_name in service_names:

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -49,21 +49,12 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     # (depending on where it's ran from?)
     service_names = ("github", "github-actions")
     result = None
-    cwd = os.getcwd()
-    log.debug(f"Current Working Directory: {cwd}")
     if base_path and os.path.exists(base_path):
         os.chdir(base_path)
-    cwd = os.getcwd()
-    log.debug(f"Current Working Directory: {cwd}")
-    for entry in os.scandir('.'):
-        if entry.is_file():
-            log.debug(entry.name)
     for service_name in service_names:
         log.info(f"Trying submitting coverage with service_name: {service_name}...")
         with patch_os_environ(repo_token, parallel, flag_name):
             coveralls = Coveralls(service_name=service_name)
-            report = coveralls.create_report()
-            log.info(report)
             try:
                 result = coveralls.wear()
                 break

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -62,6 +62,8 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
         log.info(f"Trying submitting coverage with service_name: {service_name}...")
         with patch_os_environ(repo_token, parallel, flag_name):
             coveralls = Coveralls(service_name=service_name)
+            report = coveralls.create_report()
+            log.info(report)
             try:
                 result = coveralls.wear()
                 break

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -51,6 +51,8 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     result = None
     if base_path and os.path.exists(base_path):
         os.chdir(base_path)
+    cwd = os.getcwd()
+    log.debug(f"Current Working Directory: {cwd}")
     for service_name in service_names:
         log.info(f"Trying submitting coverage with service_name: {service_name}...")
         with patch_os_environ(repo_token, parallel, flag_name):

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -30,10 +30,7 @@ def patch_os_environ(repo_token, parallel, flag_name):
     """
     # https://github.com/coveralls-clients/coveralls-python/blob/2.0.0/coveralls/api.py#L146
     parallel = "true" if parallel else ""
-    environ = {
-        "COVERALLS_REPO_TOKEN": repo_token,
-        "COVERALLS_PARALLEL": parallel
-    }
+    environ = {"COVERALLS_REPO_TOKEN": repo_token, "COVERALLS_PARALLEL": parallel}
     if flag_name:
         environ["COVERALLS_FLAG_NAME"] = flag_name
     log.debug(f"Patching os.environ with: {environ}")

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -23,19 +23,24 @@ def set_failed(message):
     sys.exit(ExitCode.FAILURE)
 
 
-def patch_os_environ(repo_token, parallel):
+def patch_os_environ(repo_token, parallel, flag_name):
     """
     Temporarily updates the environment variable to satisfy coveralls Python API.
     That is because the coveralls package API consumes mostly environment variables.
     """
     # https://github.com/coveralls-clients/coveralls-python/blob/2.0.0/coveralls/api.py#L146
     parallel = "true" if parallel else ""
-    environ = {"COVERALLS_REPO_TOKEN": repo_token, "COVERALLS_PARALLEL": parallel}
+    environ = {
+        "COVERALLS_REPO_TOKEN": repo_token,
+        "COVERALLS_PARALLEL": parallel
+    }
+    if flag_name:
+        environ["COVERALLS_FLAG_NAME"] = flag_name
     log.debug(f"Patching os.environ with: {environ}")
     return mock.patch.dict("os.environ", environ)
 
 
-def run_coveralls(repo_token, parallel=False):
+def run_coveralls(repo_token, parallel, flag_name, base_path):
     """Submits job to coveralls."""
     # note that coveralls.io "service_name" can either be:
     # - "github-actions" (local development?)
@@ -44,9 +49,11 @@ def run_coveralls(repo_token, parallel=False):
     # (depending on where it's ran from?)
     service_names = ("github", "github-actions")
     result = None
+    if base_path and os.path.exists(base_path):
+        os.chdir(base_path)
     for service_name in service_names:
         log.info(f"Trying submitting coverage with service_name: {service_name}...")
-        with patch_os_environ(repo_token, parallel):
+        with patch_os_environ(repo_token, parallel, flag_name):
             coveralls = Coveralls(service_name=service_name)
             try:
                 result = coveralls.wear()
@@ -84,6 +91,11 @@ def get_github_repository():
     return os.environ.get("GITHUB_REPOSITORY")
 
 
+def get_github_run_id():
+    """e.g. 88748489334"""
+    return os.environ.get("GITHUB_RUN_ID")
+
+
 def get_pull_request_number(github_ref):
     """
     >>> get_pull_request_number("refs/pull/<pull_request_number>/merge")
@@ -96,18 +108,10 @@ def is_pull_request(github_ref):
     return github_ref and github_ref.startswith("refs/pull/")
 
 
-def get_build_number(github_sha, github_ref):
-    build_number = github_sha
-    if is_pull_request(github_ref):
-        pull_request_number = get_pull_request_number(github_ref)
-        build_number = f"{github_sha}-PR-{pull_request_number}"
-    return build_number
-
-
 def post_webhook(repo_token):
     """https://docs.coveralls.io/parallel-build-webhook"""
     url = "https://coveralls.io/webhook"
-    build_num = get_build_number(get_github_sha(), get_github_ref())
+    build_num = get_github_run_id()
     # note this (undocumented) parameter is optional, but needed for using
     # `GITHUB_TOKEN` rather than `COVERALLS_REPO_TOKEN`
     repo_name = get_github_repository()
@@ -137,6 +141,8 @@ def str_to_bool(value):
 def parse_args():
     parser = argparse.ArgumentParser(description="Greetings")
     parser.add_argument("--github-token", nargs=1, required=True)
+    parser.add_argument("--flag-name", required=False, default=False)
+    parser.add_argument("--base-path", required=False, default=False)
     parser.add_argument(
         "--parallel", type=str_to_bool, nargs="?", const=True, default=False
     )
@@ -160,13 +166,15 @@ def main():
     debug = args.debug
     repo_token = args.github_token[0]
     parallel = args.parallel
+    flag_name = args.flag_name
+    base_path = args.base_path
     parallel_finished = args.parallel_finished
     set_log_level(debug)
     log.debug(f"args: {args}")
     if parallel_finished:
         post_webhook(repo_token)
     else:
-        run_coveralls(repo_token, parallel)
+        run_coveralls(repo_token, parallel, flag_name, base_path)
 
 
 def try_main():

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -40,7 +40,7 @@ def patch_os_environ(repo_token, parallel, flag_name):
     return mock.patch.dict("os.environ", environ)
 
 
-def run_coveralls(repo_token, parallel, flag_name, base_path):
+def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     """Submits job to coveralls."""
     # note that coveralls.io "service_name" can either be:
     # - "github-actions" (local development?)

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -51,10 +51,13 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     result = None
     cwd = os.getcwd()
     log.debug(f"Current Working Directory: {cwd}")
-    #if base_path:
-    os.chdir(base_path)
+    if base_path and os.path.exists(base_path):
+        os.chdir(base_path)
     cwd = os.getcwd()
     log.debug(f"Current Working Directory: {cwd}")
+    for entry in os.scandir('.'):
+        if entry.is_file():
+            log.debug(entry.name)
     for service_name in service_names:
         log.info(f"Trying submitting coverage with service_name: {service_name}...")
         with patch_os_environ(repo_token, parallel, flag_name):

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -49,7 +49,7 @@ def run_coveralls(repo_token, parallel=False, flag_name=False, base_path=False):
     # (depending on where it's ran from?)
     service_names = ("github", "github-actions")
     result = None
-    if base_path and os.path.exists(base_path):
+    if base_path:
         os.chdir(base_path)
     cwd = os.getcwd()
     log.debug(f"Current Working Directory: {cwd}")

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -44,7 +44,9 @@ class TestEntryPoint:
             "entrypoint.run_coveralls"
         ) as m_run_coveralls:
             entrypoint.main()
-        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False, False, False)]
+        assert m_run_coveralls.call_args_list == [
+            mock.call("TOKEN", False, False, False)
+        ]
 
     def test_main_flag_name(self):
         argv = ["src/entrypoint.py", "--github-token", "TOKEN", "--flag-name", "FLAG"]
@@ -52,7 +54,9 @@ class TestEntryPoint:
             "entrypoint.run_coveralls"
         ) as m_run_coveralls:
             entrypoint.main()
-        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False, "FLAG", False)]
+        assert m_run_coveralls.call_args_list == [
+            mock.call("TOKEN", False, "FLAG", False)
+        ]
 
     def test_main_base_path(self):
         argv = ["src/entrypoint.py", "--github-token", "TOKEN", "--base-path", "SRC"]
@@ -60,7 +64,9 @@ class TestEntryPoint:
             "entrypoint.run_coveralls"
         ) as m_run_coveralls:
             entrypoint.main()
-        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False, False, "SRC")]
+        assert m_run_coveralls.call_args_list == [
+            mock.call("TOKEN", False, False, "SRC")
+        ]
 
     def test_main_parallel_finished(self):
         argv = ["src/entrypoint.py", "--github-token", "TOKEN", "--parallel-finished"]
@@ -164,7 +170,7 @@ class TestEntryPoint:
         # 2) `GITHUB_RUN_ID` and `GITHUB_REPOSITORY` are set
         environ = {
             "GITHUB_RUN_ID": "845347868344",
-            "GITHUB_REPOSITORY": "AndreMiras/coveralls-python-action"
+            "GITHUB_REPOSITORY": "AndreMiras/coveralls-python-action",
         }
         with patch_requests_post(json_response) as m_post, patch_os_envirion(environ):
             entrypoint.post_webhook(repo_token)
@@ -181,7 +187,6 @@ class TestEntryPoint:
                 },
             )
         ]
-
 
     def test_post_webhook_error(self):
         """Coveralls.io json error response should raise an exception."""

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -44,7 +44,23 @@ class TestEntryPoint:
             "entrypoint.run_coveralls"
         ) as m_run_coveralls:
             entrypoint.main()
-        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False)]
+        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False, False, False)]
+
+    def test_main_flag_name(self):
+        argv = ["src/entrypoint.py", "--github-token", "TOKEN", "--flag-name", "FLAG"]
+        with patch_sys_argv(argv), mock.patch(
+            "entrypoint.run_coveralls"
+        ) as m_run_coveralls:
+            entrypoint.main()
+        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False, "FLAG", False)]
+
+    def test_main_base_path(self):
+        argv = ["src/entrypoint.py", "--github-token", "TOKEN", "--base-path", "SRC"]
+        with patch_sys_argv(argv), mock.patch(
+            "entrypoint.run_coveralls"
+        ) as m_run_coveralls:
+            entrypoint.main()
+        assert m_run_coveralls.call_args_list == [mock.call("TOKEN", False, False, "SRC")]
 
     def test_main_parallel_finished(self):
         argv = ["src/entrypoint.py", "--github-token", "TOKEN", "--parallel-finished"]
@@ -123,31 +139,11 @@ class TestEntryPoint:
             entrypoint.run_coveralls(repo_token="TOKEN")
         assert ex_info.value.args == (entrypoint.ExitCode.FAILURE,)
 
-    def test_get_build_number(self):
-        github_sha = "ffac537e6cbbf934b08745a378932722df287a53"
-        github_ref = "refs/pull/123/merge"
-        assert (
-            entrypoint.get_build_number(github_sha, github_ref)
-            == "ffac537e6cbbf934b08745a378932722df287a53-PR-123"
-        )
-        github_ref = "refs/heads/feature-branch-1"
-        assert (
-            entrypoint.get_build_number(github_sha, github_ref)
-            == "ffac537e6cbbf934b08745a378932722df287a53"
-        )
-        github_ref = None
-        assert (
-            entrypoint.get_build_number(github_sha, github_ref)
-            == "ffac537e6cbbf934b08745a378932722df287a53"
-        )
-
     def test_post_webhook(self):
         """
         Tests different uses cases:
         1) default, no environment variable
-        2) only `GITHUB_SHA` is set
-        3) `GITHUB_REF` is a branch
-        4) `GITHUB_REF` is a pull request
+        2) `GITHUB_RUN_ID` is set
         """
         repo_token = "TOKEN"
         json_response = {"done": True}
@@ -165,9 +161,10 @@ class TestEntryPoint:
                 },
             )
         ]
-        # 2) only `GITHUB_SHA` is set
+        # 2) `GITHUB_RUN_ID` and `GITHUB_REPOSITORY` are set
         environ = {
-            "GITHUB_SHA": "ffac537e6cbbf934b08745a378932722df287a53",
+            "GITHUB_RUN_ID": "845347868344",
+            "GITHUB_REPOSITORY": "AndreMiras/coveralls-python-action"
         }
         with patch_requests_post(json_response) as m_post, patch_os_envirion(environ):
             entrypoint.post_webhook(repo_token)
@@ -176,55 +173,15 @@ class TestEntryPoint:
                 "https://coveralls.io/webhook",
                 json={
                     "repo_token": "TOKEN",
-                    "repo_name": None,
+                    "repo_name": "AndreMiras/coveralls-python-action",
                     "payload": {
-                        "build_num": "ffac537e6cbbf934b08745a378932722df287a53",
+                        "build_num": "845347868344",
                         "status": "done",
                     },
                 },
             )
         ]
-        # 3) `GITHUB_REF` is a branch
-        environ = {
-            "GITHUB_SHA": "ffac537e6cbbf934b08745a378932722df287a53",
-            "GITHUB_REF": "refs/heads/feature-branch-1",
-        }
-        with patch_requests_post(json_response) as m_post, patch_os_envirion(environ):
-            entrypoint.post_webhook(repo_token)
-        assert m_post.call_args_list == [
-            mock.call(
-                "https://coveralls.io/webhook",
-                json={
-                    "repo_token": "TOKEN",
-                    "repo_name": None,
-                    "payload": {
-                        "build_num": "ffac537e6cbbf934b08745a378932722df287a53",
-                        "status": "done",
-                    },
-                },
-            )
-        ]
-        # 4) `GITHUB_REF` is a pull request
-        environ = {
-            "GITHUB_SHA": "ffac537e6cbbf934b08745a378932722df287a53",
-            "GITHUB_REF": "refs/pull/123/merge",
-            "GITHUB_REPOSITORY": "octocat/Hello-World",
-        }
-        with patch_requests_post(json_response) as m_post, patch_os_envirion(environ):
-            entrypoint.post_webhook(repo_token)
-        assert m_post.call_args_list == [
-            mock.call(
-                "https://coveralls.io/webhook",
-                json={
-                    "repo_token": "TOKEN",
-                    "repo_name": "octocat/Hello-World",
-                    "payload": {
-                        "build_num": "ffac537e6cbbf934b08745a378932722df287a53-PR-123",
-                        "status": "done",
-                    },
-                },
-            )
-        ]
+
 
     def test_post_webhook_error(self):
         """Coveralls.io json error response should raise an exception."""


### PR DESCRIPTION
This adds two new options (flag_name and base_path) that work the same way as they do in the main coveralls action and it fixes the calculation of the reference that is being used in the parallel_finished call.