### PR TITLE
Fix pyproject.toml support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM thekevjames/coveralls:latest
 
 COPY src/ /src/
 
+RUN python3 -m pip install "coverage[toml]"
+
 ENTRYPOINT ["/src/entrypoint.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,3 @@ relative_files = true
 [tool.coverage.report]
 show_missing = true
 exclude_lines = ["if __name__ == .__main__.:", "pragma: no-cover", "@abstract", "def __repr__"]
-
-[tool.black]
-line-length = 88
-target-version = ['py38']
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.coverage.paths]
+source = ["src", "*/site-packages"]
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = ["if __name__ == .__main__.:", "pragma: no-cover", "@abstract", "def __repr__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,14 @@ relative_files = true
 [tool.coverage.report]
 show_missing = true
 exclude_lines = ["if __name__ == .__main__.:", "pragma: no-cover", "@abstract", "def __repr__"]
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 black
 coveralls
+coverage[toml]
 flake8
 isort
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,3 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203
-
-[isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-
-[coverage:run]
-relative_files = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,13 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203
+
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+
+[coverage:run]
+relative_files = True


### PR DESCRIPTION
README express toml support. Because actions does not install toml extension so it always fails.
This PR add pyproject.toml and CI will test with the file.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>