### PR TITLE
pyproject.toml instructions updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ Under the `[tool.coverage.run]` section.
 It also requires `coverage` to be installed with the `toml` extra (`pip install coverage[toml]`):
 ```ini
 [tool.coverage.run]
-relative_files = True
+relative_files = true
 ```


### PR DESCRIPTION
`true` needs to be lowercase.

Otherwise we get:

```
  TOMLError

  Invalid TOML file ...pyproject.toml: Unexpected character: 'T' at line 32 col 17
```