### PR TITLE
Add git safe directory to workaround github actions ownership issues

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,8 +5,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
 
     - name: Unit tests
       run: make test PYTHON_WITH_VERSION=python3
@@ -38,7 +38,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Coveralls Finished
       uses: ./
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN python3 -m pip install Cython
 
 RUN python3 -m pip install "coverage[toml]"
 
-RUN git config --global --add safe.directory "/github/workspace"
+RUN git config --system --add safe.directory "/github/workspace"
 
 ENTRYPOINT ["/src/entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN python3 -m pip install Cython
 
 RUN python3 -m pip install "coverage[toml]"
 
+RUN git config --global --add safe.directory "/github/workspace"
+
 ENTRYPOINT ["/src/entrypoint.py"]

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -168,9 +168,9 @@ def main():
     import subprocess
     print("Git config before")
     subprocess.run(["git", "config", "-l", "--show-origin"])
-    subprocess.run(["git", "config", "--system", "--add", "safe.directory", "/github/workspace"])
-    print("Git config after")
-    subprocess.run(["git", "config", "-l", "--show-origin"])
+    # subprocess.run(["git", "config", "--system", "--add", "safe.directory", "/github/workspace"])
+    # print("Git config after")
+    # subprocess.run(["git", "config", "-l", "--show-origin"])
     if parallel_finished:
         post_webhook(repo_token)
     else:

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -165,12 +165,6 @@ def main():
     parallel_finished = args.parallel_finished
     set_log_level(debug)
     log.debug(f"args: {args}")
-    import subprocess
-    print("Git config before")
-    subprocess.run(["git", "config", "-l", "--show-origin"])
-    # subprocess.run(["git", "config", "--system", "--add", "safe.directory", "/github/workspace"])
-    # print("Git config after")
-    # subprocess.run(["git", "config", "-l", "--show-origin"])
     if parallel_finished:
         post_webhook(repo_token)
     else:

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -166,7 +166,11 @@ def main():
     set_log_level(debug)
     log.debug(f"args: {args}")
     import subprocess
-    subprocess.run(["git", "config", "-l"])
+    print("Git config before")
+    subprocess.run(["git", "config", "-l", "--show-origin"])
+    subprocess.run(["git", "config", "--system", "--add", "safe.directory", "/github/workspace"])
+    print("Git config after")
+    subprocess.run(["git", "config", "-l", "--show-origin"])
     if parallel_finished:
         post_webhook(repo_token)
     else:

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -165,6 +165,8 @@ def main():
     parallel_finished = args.parallel_finished
     set_log_level(debug)
     log.debug(f"args: {args}")
+    import subprocess
+    subprocess.run(["git", "config", "-l"])
     if parallel_finished:
         post_webhook(repo_token)
     else:

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -253,7 +253,7 @@ class TestEntryPoint:
         ), patch_log() as m_log:
             entrypoint.run_coveralls(repo_token="TOKEN")
         # coveralls package will retry once per service we call it with
-        assert m_post.call_count == 4
+        assert m_post.call_count == 2
         assert m_log.error.call_args_list == [
             mock.call("Failed to submit coverage", exc_info=None)
         ]


### PR DESCRIPTION
Closes #25 

As discussed in #25, new versions of git check ownership of .git directories. Until github/github actions change how docker-based actions are called, this will cause failures every time coverage/coveralls checks for metadata about the current commit. This PR is the simplest fix I could think of to accomplish this. The alternative would be to add a `subprocess.run` call in `entrypoint.py` to run the same command there. I figure since this repository is just a github action and nothing else that doing it in the Dockerfile would be fine.

When I use this on my own CI I see:

```
   File "/usr/local/lib/python3.12/site-packages/coveralls/api.py", line 301, in submit_report
    raise CoverallsException(
coveralls.exception.CoverallsException: Could not submit coverage: 422 Client Error: Unprocessable Entity for url: https://coveralls.io/api/v1/jobs

```

I'm hoping this is just a hiccup or a threshold from coveralls that they are mad about me restarting the same CI job over and over again.